### PR TITLE
Relation validation default when adding new data quality package

### DIFF
--- a/.changeset/mighty-canyons-begin.md
+++ b/.changeset/mighty-canyons-begin.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+---
+
+Data quality validation: Make relation validation default when creating data quality validation

--- a/packages/legend-extension-dsl-data-quality/src/components/DSL_DataQuality_ElementDriver.tsx
+++ b/packages/legend-extension-dsl-data-quality/src/components/DSL_DataQuality_ElementDriver.tsx
@@ -91,7 +91,8 @@ export class DataQuality_ElementDriver extends NewElementDriver<DataQualityValid
       setDqValidationElementType: action,
       runtimeOptions: computed,
     });
-    this.dqValidationElementType = DQ_VALIDATION_ELEMENT_TYPE.CLASS_VALIDATION;
+    this.dqValidationElementType =
+      DQ_VALIDATION_ELEMENT_TYPE.RELATION_VALIDATION;
     this.dqClassElementCreationBasis =
       CLASS_ELEMENT_CREATION_BASIS.DATASPACE_BASED;
     this.dataSpaceSelected = this.dataSpaceOptions[0];


### PR DESCRIPTION
## Summary

Simple ui change that selects relation validation as default instead of class validation

## How did you test this change?

Manually tested that relation validation is selected when adding new data quality package